### PR TITLE
Update for cordova-ios-4.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.radiusnetworks.cordova.proximitykit" version="0.5.1"
+<plugin id="com.radiusnetworks.cordova.proximitykit" version="0.5.2"
 xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android">
   <name>ProximityKit</name>

--- a/src/ios/RPKCDVPlugin.m
+++ b/src/ios/RPKCDVPlugin.m
@@ -73,15 +73,11 @@ NSString * const RPKCDVEventBeaconAttributesKey       = @"attributes";
 
 @implementation RPKCDVPlugin
 
--(CDVPlugin *) initWithWebView:(UIWebView *) theWebView
+- (void)pluginInitialize
 {
-  self = [super initWithWebView:(UIWebView *) theWebView];
-  if (self) {
-    self.proximityKitManager = [RPKManager managerWithDelegate:self];
-    [self.proximityKitManager start];
-    self.watchCallbacks = [[NSMutableDictionary alloc] init];
-  }
-  return self;
+  self.proximityKitManager = [RPKManager managerWithDelegate:self];
+  [self.proximityKitManager start];
+  self.watchCallbacks = [[NSMutableDictionary alloc] init];
 }
 
 - (void)dealloc


### PR DESCRIPTION
With the release of Cordova iOS 4.0.0, plugin initialization is no longer done with `initWithWebView`.  This removes that call and implements the `pluginInitialize` method instead.  I've tested this update and it is backwards compatible with previous versions of Cordova iOS.